### PR TITLE
CMakeLists with DaisySP fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,8 @@ set_target_properties(DaisySP_LGPL PROPERTIES PUBLIC
 target_include_directories(DaisySP_LGPL PUBLIC
   ${CMAKE_CURRENT_LIST_DIR}/Source
   PRIVATE
-  "../../Source"
-  "../../Source/Utility"
+  "../Source"
+  "../Source/Utility"
   "Source"
   "Source/Control"
   "Source/Dynamics"


### PR DESCRIPTION
Hey all! Thank you all so much for maintaining so many wonderful open source tools.

I have a project which is built using cmake and has the DaisySP repo as a submodule. I was super excited to try out reverbsc from DaisySP-LGPL. I added the dependency as follows
```
add_subdirectory(DaisySP)
add_subdirectory(DaisySP/DaisySP-LGPL)
```

However,  I ran into an error when trying to build
```
ggrimm@fedora:~/Desktop/CCAM-Earth-Init/build$ make
[ 16%] Built target DaisySP
[ 16%] Building CXX object DaisySP/DaisySP-LGPL/CMakeFiles/DaisySP_LGPL.dir/Source/Control/line.cpp.obj
[ 16%] Building CXX object DaisySP/DaisySP-LGPL/CMakeFiles/DaisySP_LGPL.dir/Source/Dynamics/balance.cpp.obj
/home/ggrimm/Desktop/CCAM-Earth-Init/DaisySP/DaisySP-LGPL/Source/Dynamics/balance.cpp:3:10: fatal error: dsp.h: No such file or directory
    3 | #include "dsp.h"
```

When I looked into it a bit more, it seems like the `CmakeLists.txt` is reaching too far back, and I was able to fix the issue with the following changes